### PR TITLE
Improve support for colorscheme switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Built on [colorbuddy.nvim](https://github.com/tjdevries/colorbuddy.nvim), with a
     Plug 'jesseleite/nvim-noirbuddy'
     ```
 
-2. Enable the colorscheme in your lua config:
+2. Setup the colorscheme in your lua config:
 
     > ***Note:** You can skip this step if you're using [lazy.nvim](https://github.com/folke/lazy.nvim)!*
 
@@ -65,7 +65,13 @@ Built on [colorbuddy.nvim](https://github.com/tjdevries/colorbuddy.nvim), with a
     require("noirbuddy").setup()
     ```
 
-3. Order pizza! 🍕 🤘 😎
+3. Enable the colorscheme in your lua config:
+
+    ```lua
+    vim.cmd.colorscheme("noirbuddy")
+    ```
+
+4. Order pizza! 🍕 🤘 😎
 
 ## Selecting Presets
 
@@ -82,11 +88,6 @@ require('noirbuddy').setup {
 ### Available Presets
 
 ![](presets.png)
-
-> [!CAUTION]
-> If using lazy.nvim, avoid setting `vim.opt.colorscheme` altogether, as it can cause issues with loading your configured
-> noirbuddy presets. Instead, you may use the `install = { colorscheme = { "noirbuddy" } }` configuration option.
-> See [lazy.nvim's configuration](https://lazy.folke.io/configuration) for more details.
 
 ## Customizing Your Theme
 
@@ -173,7 +174,7 @@ require("noirbuddy").setup {
 }
 ```
 
-> If you want more granular control over font styles, check out the [customizing highlight grups](#customizing-highlight-groups) section.
+> If you want more granular control over font styles, check out the [customizing highlight groups](#customizing-highlight-groups) section.
 
 ## Customizing Third Party Plugins
 
@@ -240,30 +241,31 @@ If you use a plugin that you think should be included in this repo, [PR's](https
 
 ## Customizing Highlight Groups
 
-Since Noirbuddy is built on [colorbuddy.nvim](https://github.com/tjdevries/colorbuddy.nvim), you can use its API to customize specific highlight groups as needed:
+Since Noirbuddy is built on [colorbuddy.nvim](https://github.com/tjdevries/colorbuddy.nvim), you can use its API to customize specific highlight groups as needed. To do this, define a function `custom`, where the param `c` is the colorbuddy module:
 
 ```lua
--- Require colorbuddy...
-local Color, colors, Group, groups, styles = require('colorbuddy').setup {}
+require("noirbuddy").setup {
+  custom = function(c)
+  -- Override specific highlight groups...
+  c.Group.new('TelescopeTitle', c.colors.primary)
+  c.Group.new('TelescopeBorder', c.colors.secondary)
+  c.Group.new('CursorLineNr', c.colors.primary, c.colors.noir_9)
+  c.Group.new('Searchlight', nil, c.colors.secondary)
+  c.Group.new('@comment', c.colors.noir_7)
+  c.Group.new('@punctuation', c.colors.noir_2)
 
--- Override specific highlight groups...
-Group.new('TelescopeTitle', colors.primary)
-Group.new('TelescopeBorder', colors.secondary)
-Group.new('CursorLineNr', colors.primary, colors.noir_9)
-Group.new('Searchlight', nil, colors.secondary)
-Group.new('@comment', colors.noir_7)
-Group.new('@punctuation', colors.noir_2)
+  -- Add font styles to highlight groups...
+  c.Group.new('@constant', c.colors.noir_2, nil, c.styles.bold)
+  c.Group.new('@method', c.colors.noir_0, nil, c.styles.bold + c.styles.italic)
 
--- Add font styles to highlight groups...
-Group.new('@constant', colors.noir_2, nil, styles.bold)
-Group.new('@method', colors.noir_0, nil, styles.bold + styles.italic)
+  -- Link highlight groups...
+  c.Group.link('SignifySignAdd', c.groups.DiffAdd)
+  c.Group.link('SignifySignChange', c.groups.DiffChange)
+  c.Group.link('SignifySignDelete', c.groups.DiffDelete)
 
--- Link highlight groups...
-Group.link('SignifySignAdd', groups.DiffAdd)
-Group.link('SignifySignChange', groups.DiffChange)
-Group.link('SignifySignDelete', groups.DiffDelete)
-
--- etc.
+  -- etc.
+  end
+}
 ```
 
 ## Exporting Colors

--- a/colors/noirbuddy.lua
+++ b/colors/noirbuddy.lua
@@ -1,1 +1,1 @@
-require('noirbuddy').setup()
+require("noirbuddy").load()

--- a/lua/noirbuddy/init.lua
+++ b/lua/noirbuddy/init.lua
@@ -6,13 +6,15 @@ function M.setup(opts)
   M.options = opts
 end
 
-function M.load()
+function M.load(opts)
+  opts = vim.tbl_extend("force", M.options, opts or {})
+
   vim.api.nvim_command("highlight clear")
   vim.api.nvim_command("set termguicolors")
   vim.api.nvim_command(string.format("set background=%s", "dark"))
 
-  require("noirbuddy.colors").setup(M.options)
-  require("noirbuddy.theme").setup(M.options)
+  require("noirbuddy.colors").setup(opts)
+  require("noirbuddy.theme").setup(opts)
   require("noirbuddy.plugins")
   require("noirbuddy.languages")
 

--- a/lua/noirbuddy/init.lua
+++ b/lua/noirbuddy/init.lua
@@ -18,6 +18,10 @@ function M.load(opts)
   require("noirbuddy.plugins")
   require("noirbuddy.languages")
 
+  if opts.custom ~= nil then
+    opts.custom(require("colorbuddy"))
+  end
+
   vim.api.nvim_command(string.format('let g:colors_name = "%s"', "noirbuddy"))
 end
 

--- a/lua/noirbuddy/init.lua
+++ b/lua/noirbuddy/init.lua
@@ -7,6 +7,7 @@ function M.setup(opts)
 end
 
 function M.load()
+  vim.api.nvim_command("highlight clear")
   vim.api.nvim_command("set termguicolors")
   vim.api.nvim_command(string.format("set background=%s", "dark"))
 

--- a/lua/noirbuddy/init.lua
+++ b/lua/noirbuddy/init.lua
@@ -1,17 +1,21 @@
 local M = {}
 
+M.options = nil
+
 function M.setup(opts)
-  opts = opts or {}
+  M.options = opts
+end
 
+function M.load()
   vim.api.nvim_command("set termguicolors")
-  vim.api.nvim_command(string.format("set background=%s", 'dark'))
+  vim.api.nvim_command(string.format("set background=%s", "dark"))
 
-  require('noirbuddy.colors').setup(opts)
-  require('noirbuddy.theme').setup(opts)
-  require('noirbuddy.plugins')
-  require('noirbuddy.languages')
+  require("noirbuddy.colors").setup(M.options)
+  require("noirbuddy.theme").setup(M.options)
+  require("noirbuddy.plugins")
+  require("noirbuddy.languages")
 
-  vim.api.nvim_command(string.format('let g:colors_name = "%s"', 'noirbuddy'))
+  vim.api.nvim_command(string.format('let g:colors_name = "%s"', "noirbuddy"))
 end
 
 return M


### PR DESCRIPTION
This PR separates initialisation of the colorscheme from actually enabling the colorscheme.

`setup` now only stores the configuration, and a separate call to `load` is required to activate the colorscheme. This seems to be how larger colorschemes do it – I looked at [folke/tokyonight.nvim](https://github.com/folke/tokyonight.nvim) and [marko-cerovac/material.nvim](https://github.com/marko-cerovac/material.nvim).

The benefit is that it enables the user to switch back and forth using `:colorscheme` without losing their settings. I believe this should solve the confusion in #12 .

`load` also takes opts, which will extend those used for `setup`. So if I wanted to have several noirbuddy configs to switch between I could create files in the `colors` dir of my neovim config root like this:

```
// colors/noirbuddy-alt
require("noirbuddy").load({
  colors = {
    ...
  }
})
```

Which I can then activate using: `:colorscheme noirbuddy-alt`.

What do you think?