### PR TITLE
Override inherited string defaults

### DIFF
--- a/lua/noirbuddy/theme.lua
+++ b/lua/noirbuddy/theme.lua
@@ -198,6 +198,9 @@ function M.setup(opts)
   Group.new('DiffAdd', colors.diff_add)
   Group.new('DiffChange', colors.diff_change)
   Group.new('DiffDelete', colors.diff_delete)
+
+  -- Override Colorbuddy Defaults
+  Group.new('string', colors.primary)
 end
 
 return M


### PR DESCRIPTION
Setting the `"string"` group to `colors.primary` to achieve theming consistency between different languages.

Resolves #21 

![image](https://github.com/user-attachments/assets/a81dc4b6-2e65-458d-abc7-62e91eecb0a9)
